### PR TITLE
MISC: Sync changed composer files to guest

### DIFF
--- a/lib/hem/tasks/magento2/sample_data.rb
+++ b/lib/hem/tasks/magento2/sample_data.rb
@@ -33,6 +33,7 @@ namespace :sample_data do
         begin
           shell(*args)
 
+          execute_if_defined('deps:sync:composer_files_to_guest')
           execute_if_defined('vm:rsync_mount_sync')
 
           complete = true

--- a/lib/hem/tasks/magento2/version.rb
+++ b/lib/hem/tasks/magento2/version.rb
@@ -1,7 +1,7 @@
 module Hem
   module Tasks
     module Magento2
-      VERSION = '2.0.0'.freeze
+      VERSION = '2.1.0'.freeze
     end
   end
 end


### PR DESCRIPTION
If sample data was installed locally, it will have updated the composer.json and lock, so sync them to the VM.
