### PR TITLE
Always run magento2 setup

### DIFF
--- a/lib/hem/tasks/magento2/configure.rb
+++ b/lib/hem/tasks/magento2/configure.rb
@@ -7,8 +7,11 @@ task :configure do
   configuration_file = File.join(Hem.project_config.vm.project_mount_path, 'configure-magento-config.php')
   run_command "php #{configuration_file}", realtime: true, indent: 2
 
-  [File.join(Hem.project_path, 'var', 'cache'), File.join(Hem.project_path, 'var', 'page_cache')].each do |dir|
-    FileUtils.rm_rf("#{dir}/.", secure: true)
+  [
+    File.join(Hem.project_config.vm.project_mount_path, 'var', 'cache'),
+    File.join(Hem.project_config.vm.project_mount_path, 'var', 'page_cache')
+  ].each do |dir|
+    run "sudo rm -rf '#{dir}/.'", realtime: true, indent: 2
   end
 
   Hem.ui.success('Magento2 configuration update finished')

--- a/lib/hem/tasks/magento2/configure.rb
+++ b/lib/hem/tasks/magento2/configure.rb
@@ -11,7 +11,7 @@ task :configure do
     File.join(Hem.project_config.vm.project_mount_path, 'var', 'cache'),
     File.join(Hem.project_config.vm.project_mount_path, 'var', 'page_cache')
   ].each do |dir|
-    run "sudo rm -rf '#{dir}/.'", realtime: true, indent: 2
+    run "sudo rm -rf '#{dir}/*'", realtime: true, indent: 2
   end
 
   Hem.ui.success('Magento2 configuration update finished')

--- a/lib/hem/tasks/magento2/install.rb
+++ b/lib/hem/tasks/magento2/install.rb
@@ -35,15 +35,16 @@ namespace :install do
 
       Rake::Task['magento2:configure'].invoke
       Rake::Task['magento2:sample_data:add'].invoke(from_install: true)
-      Rake::Task['magento2:setup_script:run'].invoke
-      Rake::Task['magento2:index:refresh'].invoke
-      Rake::Task['magento2:cache:clean'].invoke
-      Rake::Task['magento2:development:asset_symlinks'].invoke
-      Rake::Task['magento2:development:compile_less'].invoke
     end
 
     Rake::Task['magento2:install:set_permissions'].execute
     Rake::Task['magento2:install:optimise_autoloader'].invoke
+
+    Rake::Task['magento2:setup_script:run'].invoke
+    Rake::Task['magento2:index:refresh'].invoke
+    Rake::Task['magento2:cache:clean'].invoke
+    Rake::Task['magento2:development:asset_symlinks'].invoke
+    Rake::Task['magento2:development:compile_less'].invoke
   end
 
   desc 'Optimise the composer autoloader for a speed boost'

--- a/lib/hem/tasks/magento2/version.rb
+++ b/lib/hem/tasks/magento2/version.rb
@@ -1,7 +1,7 @@
 module Hem
   module Tasks
     module Magento2
-      VERSION = '2.1.0'.freeze
+      VERSION = '2.2.0'.freeze
     end
   end
 end


### PR DESCRIPTION
Stops the situation where the code has moved on with the database dump, and a manual application of `bin/magento setup:upgrade` would need running for a new VM.
