### PR TITLE
Fix static content deploy under magento 2.0.x

### DIFF
--- a/lib/hem/tasks/magento2/development.rb
+++ b/lib/hem/tasks/magento2/development.rb
@@ -12,6 +12,12 @@ namespace :development do
 
   desc 'Compile the less files'
   task :compile_less do
+    Rake::Task['magento2:development:compile_less_frontend'].invoke
+    Rake::Task['magento2:development:compile_less_backend'].invoke
+  end
+
+  desc 'Compile the less files for the frontend themes'
+  task :compile_less_frontend do
     Hem.ui.title 'Compiling Less files for the en_GB frontend'
     run_command 'bin/magento setup:static-content:deploy --no-javascript '\
                 '--no-images --no-html --no-misc --no-fonts --no-css '\
@@ -20,6 +26,10 @@ namespace :development do
                 realtime: true,
                 indent: 2
     Hem.ui.success('Compile finished')
+  end
+
+  desc 'Compile the less files for the admin/backend themes'
+  task :compile_less_backend do
 
     Hem.ui.title 'Compiling Less files for the en_GB and en_US backend'
     run_command 'bin/magento setup:static-content:deploy --no-javascript '\

--- a/lib/hem/tasks/magento2/development.rb
+++ b/lib/hem/tasks/magento2/development.rb
@@ -18,6 +18,11 @@ namespace :development do
 
   desc 'Compile the less files for the frontend themes'
   task :compile_less_frontend do
+    has_javascript_option = run 'bin/magento setup:static-content:deploy --help | grep -- --no-javascript || true',
+                            capture: true
+
+    next unless has_javascript_option
+
     Hem.ui.title 'Compiling Less files for the en_GB frontend'
     run_command 'bin/magento setup:static-content:deploy --no-javascript '\
                 '--no-images --no-html --no-misc --no-fonts --no-css '\
@@ -30,6 +35,10 @@ namespace :development do
 
   desc 'Compile the less files for the admin/backend themes'
   task :compile_less_backend do
+    has_javascript_option = run 'bin/magento setup:static-content:deploy --help | grep -- --no-javascript || true',
+                            capture: true
+
+    next unless has_javascript_option
 
     Hem.ui.title 'Compiling Less files for the en_GB and en_US backend'
     run_command 'bin/magento setup:static-content:deploy --no-javascript '\

--- a/lib/hem/tasks/magento2/development.rb
+++ b/lib/hem/tasks/magento2/development.rb
@@ -21,7 +21,7 @@ namespace :development do
     has_javascript_option = run 'bin/magento setup:static-content:deploy --help | grep -- --no-javascript || true',
                             capture: true
 
-    next unless has_javascript_option
+    next if has_javascript_option == ''
 
     Hem.ui.title 'Compiling Less files for the en_GB frontend'
     run_command 'bin/magento setup:static-content:deploy --no-javascript '\
@@ -38,7 +38,7 @@ namespace :development do
     has_javascript_option = run 'bin/magento setup:static-content:deploy --help | grep -- --no-javascript || true',
                             capture: true
 
-    next unless has_javascript_option
+    next if has_javascript_option == ''
 
     Hem.ui.title 'Compiling Less files for the en_GB and en_US backend'
     run_command 'bin/magento setup:static-content:deploy --no-javascript '\

--- a/lib/hem/tasks/magento2/version.rb
+++ b/lib/hem/tasks/magento2/version.rb
@@ -1,7 +1,7 @@
 module Hem
   module Tasks
     module Magento2
-      VERSION = '2.4.0'.freeze
+      VERSION = '2.5.0'.freeze
     end
   end
 end


### PR DESCRIPTION
Magento 2.0.x does not have all the options we are using on the `setup:static-content:deploy` task, so there is no way to target just the LESS file compilation.

Also, split the backend and frontend compilation tasks, as some projects fail with the frontend compilation. Potentially it's when they have custom themes.
