### PR TITLE
Allow for non bind mounted var directory

### DIFF
--- a/lib/hem/tasks/magento2/version.rb
+++ b/lib/hem/tasks/magento2/version.rb
@@ -1,7 +1,7 @@
 module Hem
   module Tasks
     module Magento2
-      VERSION = '2.5.0'.freeze
+      VERSION = '2.6.0'.freeze
     end
   end
 end


### PR DESCRIPTION
XDebug does not work easily when var/generation is not present on the host.
As vendor directory was the cause of slowness, let's allow for var being back over NFS, which doesn't support ACL.
